### PR TITLE
chore: ignore health/alive route in sentry

### DIFF
--- a/app/sentry.client.ts
+++ b/app/sentry.client.ts
@@ -15,14 +15,6 @@ export function initSentry() {
     dsn: browserConfig.sentryDSN,
     integrations: [
       new Sentry.BrowserTracing({
-        // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
-        // Headers are only attached to requests that are from web wallet project in their URL.
-        tracePropagationTargets: [
-          // Exclude build path and Log Rocket requests from performance.
-          // Context about Log Rocket:
-          // Sentry adds baggage to the request body and Log Rocket are very strict to yours payload, giving CORS error if extra param is attached.
-          /^\/?((?!(build?.+|\.lr-.+\.com)).)*$/gim,
-        ],
         routingInstrumentation: Sentry.remixRouterInstrumentation(
           useEffect,
           useLocation,
@@ -45,6 +37,17 @@ export function initSentry() {
         maskAllInputs: false,
         blockAllMedia: false,
       }),
+    ],
+    // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+    // Headers are only attached to requests that are from web wallet project in their URL.
+    tracePropagationTargets: [
+      // Exclude build path and Log Rocket requests from performance.
+      // Context about Log Rocket:
+      // Sentry adds baggage to the request body and Log Rocket are very strict to yours payload, giving CORS error if extra param is attached.
+      /^\/?((?!(health\/alive?.+)).)*$/gim,
+      /^\/?((?!(build?.+)).)*$/gim,
+      /^\/?((?!(\.awswaf.com)).)*$/gim,
+      /^\/?((?!(\.googleapis.com)).)*$/gim,
     ],
     ignoreErrors: ['query() call aborted', 'queryRoute() call aborted'],
     // Performance Monitoring

--- a/app/sentry.server.ts
+++ b/app/sentry.server.ts
@@ -11,6 +11,17 @@ export function initSentry() {
     environment: config.ENV,
     dsn: config.sentryDSN,
     integrations: [new Sentry.Integrations.Http({ tracing: true })],
+    // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+    // Headers are only attached to requests that are from web wallet project in their URL.
+    tracePropagationTargets: [
+      // Exclude build path and Log Rocket requests from performance.
+      // Context about Log Rocket:
+      // Sentry adds baggage to the request body and Log Rocket are very strict to yours payload, giving CORS error if extra param is attached.
+      /^\/?((?!(health\/alive?.+)).)*$/gim,
+      /^\/?((?!(build?.+)).)*$/gim,
+      /^\/?((?!(\.awswaf.com)).)*$/gim,
+      /^\/?((?!(\.googleapis.com)).)*$/gim,
+    ],
     ignoreErrors: ['query() call aborted', 'queryRoute() call aborted'],
     // Performance Monitoring
     tracesSampleRate: 1.0, // opting to record 100% of all transactions in all envs for now


### PR DESCRIPTION
## Summary
Ignores the `/health/alive` route from being consumed by trace propagation of Sentry.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- updated ignore regex

## Testing
Tested regex match.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [x] Any dependent changes have been merged and published in upstream projects