### PR TITLE
fix: accepts min 1 digit for date and month

### DIFF
--- a/app/validations/date.schema.ts
+++ b/app/validations/date.schema.ts
@@ -1,7 +1,7 @@
 import * as zod from 'zod';
 
 export const USDateSchema = zod.string().refine((value: string) => {
-  const regex = /^\d{2}\/\d{2}\/\d{4}$/;
+  const regex = /^\d{1,2}\/\d{1,2}\/\d{4}$/;
   if (regex.test(value)) {
     const date = Date.parse(String(new Date(value)));
     return !isNaN(date);


### PR DESCRIPTION
## Summary
Fixes the DOB input validity to accept date and month without zero pads.

[Ticket](https://verified-network.sentry.io/issues/5635893484/?environment=production&project=4506752181993472&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=0)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- updated dob field

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects